### PR TITLE
Fix BigFloat Sign

### DIFF
--- a/src/BigFloat.cs
+++ b/src/BigFloat.cs
@@ -20,7 +20,14 @@ class BigFloat : IComparable, IComparable<BigFloat>, IEquatable<BigFloat>
     {
         get
         {
-            return numerator.Sign;
+            switch(numerator.Sign + denominator.Sign) {
+                case 2: case -2:
+                    return 1;
+                case 0:
+                    return -1;
+                default:
+                    return 0;
+            }
         }
     }
 


### PR DESCRIPTION
Now:
BigFloat bf = -5;
BigFloat bf2 = bf / -5;

Console.WriteLine(bf2.Sign);
// writes "-1" --> 1 != -1 which is incorrect.

There are many functions whose changes the denominator sign. Its easier to calculate this way.