### PR TITLE
fix BigFloat zero ^ negative = a / 0

### DIFF
--- a/src/BigFloat.cs
+++ b/src/BigFloat.cs
@@ -158,7 +158,11 @@ class BigFloat : IComparable, IComparable<BigFloat>, IEquatable<BigFloat>
     }
     public BigFloat Pow(int exponent)
     {
-        if (exponent < 0)
+        if (numerator.IsZero)
+        {
+            // Nothing to do
+        }
+        else if (exponent < 0)
         {
             BigInteger savedNumerator = numerator;
             numerator = BigInteger.Pow(denominator, -exponent);


### PR DESCRIPTION
BigFloat bf = 0;
BigFloat bf2 = bf ^ -1;
This case the denominator turn to 0 which cause unexpected behaviours