### PR TITLE
Fix Log(double baseValue) Method

### DIFF
--- a/src/BigFloat.cs
+++ b/src/BigFloat.cs
@@ -558,7 +558,7 @@ class BigFloat : IComparable, IComparable<BigFloat>, IEquatable<BigFloat>
     }
     public static BigFloat operator +(BigFloat value)
     {
-        return (new BigFloat(value)).Abs();
+        return value;
     }
     public static BigFloat operator ++(BigFloat value)
     {

--- a/src/BigFloat.cs
+++ b/src/BigFloat.cs
@@ -279,7 +279,7 @@ class BigFloat : IComparable, IComparable<BigFloat>, IEquatable<BigFloat>
     }
     public double Log(double baseValue)
     {
-        return BigInteger.Log(numerator, baseValue) - BigInteger.Log(numerator, baseValue);
+        return BigInteger.Log(numerator, baseValue) - BigInteger.Log(denominator, baseValue);
     }
     public override string ToString()
     {


### PR DESCRIPTION
### Fix Log(double baseValue) Method
Changed the ``Log(double baseValue)`` method to fix a typo where the log of the numerator was subtracted from itself meaning the method would always return zero.

New method is :
```
public double Log(double baseValue)
{
    return BigInteger.Log(numerator, baseValue) - BigInteger.Log(denominator, baseValue);
}
```
Rather than :
```
public double Log(double baseValue)
{
    return BigInteger.Log(numerator, baseValue) - BigInteger.Log(numerator, baseValue);
}
```

### Proposed Change to Unary + Operator
Typically, the unary ``+`` operator is expected to return the value itself without any modifications. However, in this implementation the unary ``+`` operator is returning the absolute value of the BigFloat instance. This behaviour deviates from the standard expectation and could lead to confusion for users of the BigFloat class. For example :
```
BigFloat negativeValue = new BigFloat(-5);
BigFloat result = +negativeValue;
// This will return the absolute value (5), not -5.
```
If the intention is to adhere to the standard behaviour of the unary ``+`` operator (i.e., returning the value as-is), the implementation should simply return the input value without modification. This ensures that the unary ``+`` operator behaves as expected, acting as a no-op.

Proposed new code :
```
public static BigFloat operator +(BigFloat value)
{
    return value;
}
```
Rather than :
```
public static BigFloat operator +(BigFloat value)
{
    return (new BigFloat(value)).Abs();
}
```